### PR TITLE
Faster indexing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rarr
 Title: A Simple and Performant Native R Reader & Writer for Zarr Arrays
-Version: 2.1.37
+Version: 2.1.38
 Authors@R: c(
     person("Mike", "Smith", role = c("aut", "ccp"),
            comment = c(ORCID = "0000-0002-7800-3848", "Maintainer from 2022 to 2025.")),

--- a/R/utils_altrep.R
+++ b/R/utils_altrep.R
@@ -1,6 +1,9 @@
 is.compact <- function(x) {
   .Call("is_compact", x, PACKAGE = "Rarr")
 }
+is.scalar <- function(x) {
+  is.atomic(x) && length(x) == 1L
+}
 
 reindex <- function(x, from = 1L, to = 0L) {
   offset <- from - to

--- a/R/utils_chunk.R
+++ b/R/utils_chunk.R
@@ -77,7 +77,8 @@
       chunk_dim,
       SIMPLIFY = FALSE
     )
-    in_chunk <- lapply(per_dim, \(pd) lapply(pd, seq_along))
+    # Faster than nested lapply()
+    in_chunk <- rapply(per_dim, seq_along, how = "list")
   } else {
     flat0 <- unlist(lapply(index, reindex, from = 1L, to = 0L))
     cs <- rep(chunk_dim, times = lengths(index))

--- a/R/utils_chunk.R
+++ b/R/utils_chunk.R
@@ -62,7 +62,11 @@
   # FIXME:
   # - make this work for compat sequence that don't start at one
   if (
-    all(vapply(index, is.compact, logical(1L))) &&
+    all(vapply(
+      index,
+      function(x) is.compact(x) || is.scalar(x),
+      logical(1L)
+    )) &&
       all(vapply(index, min, integer(1L)) == 1L)
   ) {
     per_dim <- mapply(

--- a/R/utils_chunk.R
+++ b/R/utils_chunk.R
@@ -79,7 +79,7 @@
     )
     in_chunk <- lapply(per_dim, \(pd) lapply(pd, seq_along))
   } else {
-    flat0 <- unlist(index) - 1L
+    flat0 <- unlist(lapply(index, reindex, from = 1L, to = 0L))
     cs <- rep(chunk_dim, times = lengths(index))
     id <- flat0 %/% cs
     # We compute the remainder "manually" to avoid expensive %% call,

--- a/R/utils_chunk.R
+++ b/R/utils_chunk.R
@@ -55,13 +55,10 @@
   metadata,
   chunk_dim = unlist(metadata$chunk_grid$configuration$chunk_shape)
 ) {
-  index0 <- lapply(index, reindex, from = 1L, to = 0L)
   if (!is.integer(chunk_dim)) {
     chunk_dim <- as.integer(chunk_dim)
   }
-  # FIXME:
-  # - make this work for compat sequence that don't start at one
-  # - fold the second step (index_in_chunk) here
+
   if (
     all(vapply(index, is.compact, logical(1L))) &&
       all(vapply(index, min, integer(1L)) == 1L)
@@ -80,31 +77,36 @@
       chunk_dim,
       SIMPLIFY = FALSE
     )
+    in_chunk <- lapply(per_dim, \(pd) lapply(pd, seq_along))
   } else {
-    index0 <- unlist(index0)
-    per_dim <- (index0 %/% rep(chunk_dim, times = lengths(index))) |>
-      relist(index) |>
-      lapply(function(x) split(seq_along(x), x))
-    index0 <- relist(index0, index)
+    flat0 <- unlist(index) - 1L
+    cs <- rep(chunk_dim, times = lengths(index))
+    id <- flat0 %/% cs
+    # We compute the remainder "manually" to avoid expensive %% call,
+    # when %/% did all the work already
+    rem <- flat0 - id * cs
+    per_dim <- relist(id, index) |>
+      lapply(\(x) split(seq_along(x), x))
+    in_chunk <- mapply(
+      \(rem, pd) lapply(pd, \(pos) rem[pos] + 1L),
+      relist(rem, index),
+      per_dim,
+      SIMPLIFY = FALSE
+    )
   }
+
   chunk_keys <- do.call(expand.grid, lapply(per_dim, names))
   key_strings <- .create_chunk_names(chunk_keys, metadata)
+  key_pos <- do.call(expand.grid, lapply(per_dim, seq_along))
+
+  # Transpose the list to get the result per chunk, rather than per dimension.
   setNames(
-    lapply(seq_along(key_strings), function(i) {
-      positions <- mapply(
-        \(d, k) d[[k]],
-        per_dim,
-        chunk_keys[i, ],
-        SIMPLIFY = FALSE
+    lapply(seq_len(nrow(key_pos)), \(i) {
+      k <- key_pos[i, ]
+      list(
+        positions = mapply(\(d, kk) d[[kk]], per_dim, k, SIMPLIFY = FALSE),
+        index_in_chunk = mapply(\(d, kk) d[[kk]], in_chunk, k, SIMPLIFY = FALSE)
       )
-      index_in_chunk <- mapply(
-        \(idx, pos, cs) reindex(idx[pos] %% cs, from = 0L, to = 1L),
-        index0,
-        positions,
-        chunk_dim,
-        SIMPLIFY = FALSE
-      )
-      list(positions = positions, index_in_chunk = index_in_chunk)
     }),
     key_strings
   )

--- a/R/utils_chunk.R
+++ b/R/utils_chunk.R
@@ -59,6 +59,8 @@
     chunk_dim <- as.integer(chunk_dim)
   }
 
+  # FIXME:
+  # - make this work for compat sequence that don't start at one
   if (
     all(vapply(index, is.compact, logical(1L))) &&
       all(vapply(index, min, integer(1L)) == 1L)

--- a/R/utils_chunk.R
+++ b/R/utils_chunk.R
@@ -89,8 +89,8 @@
     per_dim <- relist(id, index) |>
       lapply(\(x) split(seq_along(x), x))
     in_chunk <- mapply(
-      \(rem, pd) lapply(pd, \(pos) rem[pos] + 1L),
-      relist(rem, index),
+      \(rem, pd) lapply(pd, \(pos) rem[pos]),
+      relist(rem + 1L, index),
       per_dim,
       SIMPLIFY = FALSE
     )


### PR DESCRIPTION
```r
cross::bench_branches({
  library(Rarr)
  bench::mark(
     SpatialData.data::MouseIntestineVisHD(), iterations = 1
  )
}, branches = "devel")
```

```
✔ Installing branch 'faster-indexing-august2026'
✔ Installing branch 'devel'
✔ Running `expr` across variants
# A tibble: 2 × 14
  branch                     expression       min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result     memory     time       gc      
  <chr>                      <bch:expr>     <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>     <list>     <list>     <list>  
1 faster-indexing-august2026 SpatialData.d… 3.37m  3.37m   0.00495    58.6GB    0.114     1    23      3.37m <SpatilDt> <Rprofmem> <bench_tm> <tibble>
2 devel                      SpatialData.d… 3.48m  3.48m   0.00479    70.3GB    0.115     1    24      3.48m <SpatilDt> <Rprofmem> <bench_tm> <tibble>
```